### PR TITLE
Two features ready for review

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,0 +1,101 @@
+from typing import Set
+import bpy
+from bpy.types import Context
+
+class DoImg(bpy.types.Operator):
+    bl_idname = "object.do_img"
+    bl_label = "Place Image"
+    
+    #Property that holds the filepath that will be used to insert the image
+    myFilePath: bpy.props.StringProperty(subtype="FILE_PATH")
+
+    #This is the function that inserts the image into blender
+    def execute(self, context):
+        bpy.ops.object.load_reference_image(filepath=self.myFilePath)
+        return {'FINISHED'}
+    
+    #This is a function that opens a file explorer
+    #THIS DOES NOT DO ANYTHING I just think its going to be useful to have later
+    def invoke(self, context, event):
+        # Open a file browser to select a file
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+class LayoutDemoPanel(bpy.types.Panel):
+    """Creates a Panel in the scene context of the properties editor"""
+    bl_label = "Layout Demo"
+    bl_idname = "SCENE_PT_layout"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "scene"
+
+    def draw(self, context):
+        layout = self.layout
+
+        scene = context.scene
+
+        # Big save button
+        layout.label(text="Big Button:")
+        row = layout.row()
+        row.scale_y = 2.0
+        row.operator("wm.save_mainfile")
+        
+        #front file path
+        row = layout.row()
+        row.prop(context.scene, "front_views_file_path", text="Front View")
+
+        #right file path
+        row = layout.row()
+        row.prop(context.scene, "right_views_file_path", text="Right View")
+
+        #left file path
+        row = layout.row()
+        row.prop(context.scene, "left_views_file_path", text="Left View")
+
+        #back file path
+        row = layout.row()
+        row.prop(context.scene, "back_views_file_path", text="Back View")
+
+        #top file path
+        row = layout.row()
+        row.prop(context.scene, "top_views_file_path", text="Top View")
+
+        #bottom file path
+        row = layout.row()
+        row.prop(context.scene, "bottom_views_file_path", text="Bottom View")
+        
+        # Big image button
+        layout.label(text="Big Button:")
+        row = layout.row()
+        row.scale_y = 2.0
+        #The operator is a DoImg object
+        do_img_op = row.operator("object.do_img")
+        #The filepath for the image is passed in here to be used
+        do_img_op.myFilePath = context.scene.front_views_file_path
+
+#A function that initializes all of the classes and views in the file
+def register():
+    bpy.utils.register_class(LayoutDemoPanel)
+    bpy.utils.register_class(DoImg)
+    bpy.types.Scene.front_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.right_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.left_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.back_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.top_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.bottom_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+
+#A functoin that deconstructs the classes and views in the file
+def unregister():
+    bpy.utils.unregister_class(LayoutDemoPanel)
+    bpy.utils.register_class(DoImg)
+    bpy.types.Scene.front_views_file_path
+    bpy.types.Scene.right_views_file_path
+    bpy.types.Scene.left_views_file_path
+    bpy.types.Scene.back_views_file_path
+    bpy.types.Scene.top_views_file_path
+    bpy.types.Scene.bottom_views_file_path 
+
+
+#This calls register
+if __name__ == "__main__":
+    register()

--- a/save.py
+++ b/save.py
@@ -1,0 +1,80 @@
+import bpy
+
+def main(context):
+    bpy.ops.wm.save_as_mainfile(filepath="c:\Users\James Burns\Documents\TestFile.blend")
+
+class Save(bpy.types.Operator):
+    bl_idname = "object.Save"
+    bl_label = "Place Image"
+
+    def execute(self, context):
+        main(context)
+        return {'FINISHED'}
+
+class LayoutDemoPanel(bpy.types.Panel):
+    """Creates a Panel in the scene context of the properties editor"""
+    bl_label = "Layout Demo"
+    bl_idname = "SCENE_PT_layout"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "scene"
+
+    def draw(self, context):
+        layout = self.layout
+
+        scene = context.scene
+
+        # Big render button
+        layout.label(text="Big Button:")
+        row = layout.row()
+        row.scale_y = 2.0
+        row.operator("object.Save")
+        
+        #front file path
+        row = layout.row()
+        row.prop(context.scene, "front_views_file_path", text="Front View")
+
+        #right file path
+        row = layout.row()
+        row.prop(context.scene, "right_views_file_path", text="Right View")
+
+        #left file path
+        row = layout.row()
+        row.prop(context.scene, "left_views_file_path", text="Left View")
+
+        #back file path
+        row = layout.row()
+        row.prop(context.scene, "back_views_file_path", text="Back View")
+
+        #top file path
+        row = layout.row()
+        row.prop(context.scene, "top_views_file_path", text="Top View")
+
+        #bottom file path
+        row = layout.row()
+        row.prop(context.scene, "bottom_views_file_path", text="Bottom View")
+
+
+def register():
+    bpy.utils.register_class(LayoutDemoPanel)
+    bpy.types.Scene.front_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.right_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.left_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.back_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.top_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+    bpy.types.Scene.bottom_views_file_path = bpy.props.StringProperty(subtype="FILE_PATH")
+
+
+def unregister():
+    bpy.utils.unregister_class(LayoutDemoPanel)
+    bpy.types.Scene.front_views_file_path
+    bpy.types.Scene.right_views_file_path
+    bpy.types.Scene.left_views_file_path
+    bpy.types.Scene.back_views_file_path
+    bpy.types.Scene.top_views_file_path
+    bpy.types.Scene.bottom_views_file_path 
+
+
+
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
I have created the functionality for both importing an image into blender and saving the current file in blender. Plugin.py has all of the functionality in one file while the save.py just has the save functionality. Something to note is that the importing images will only work with the front image and only if the front image has a file destination ready. More steps will be needed to import different or all images although the code is all there you would just have to copy and paste for the different views.